### PR TITLE
disable navbar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,9 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
+
+  private
+  def disable_nav
+   @disable_nav = true
+  end
 end

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -1,5 +1,7 @@
 class BookingsController < ApplicationController
   before_action :set_booking, only: %i(show edit accept reject destroy)
+  before_action :disable_nav, only: [:edit]
+
 
   def show
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,8 @@
     <%= stylesheet_link_tag    'application', media: 'all' %>
   </head>
   <body>
+    <%= render 'shared/navbar' unless @disable_nav %>
     <%= render 'shared/flashes' %>
-    <%= render 'shared/navbar' %>
 
 
     <%= javascript_include_tag "https://maps.google.com/maps/api/js?key=#{ENV.fetch('GOOGLE_API_BROWSER_KEY')}" %>


### PR DESCRIPTION
Yo la team, je viens de faire une petite méthode pour désactiver la nav barre, c'est utile pour certaines pages d'apres les mock up d'Amélie. 
Il vous suffie de mettre un before action dans le controlleur de page voulu : before_action :disable_nav, only: [:'#l'action en question'] 